### PR TITLE
docs: adiciona arquivos de prontidão para agentes de IA

### DIFF
--- a/.github/instructions/agents-instructions.md
+++ b/.github/instructions/agents-instructions.md
@@ -1,0 +1,151 @@
+# PO Theme TOTVS - Instruções para AI Coding Agents
+
+## Visão Geral do Projeto
+
+O `@totvs/po-theme` é o tema padrão da TOTVS para aplicações construídas com o framework PO UI. Estende e customiza o `@po-ui/style` com branding TOTVS (cores, tipografia, espaçamentos).
+
+> **ATENÇÃO**: Este repositório está em processo de descontinuação. Suporte até v23.x.x. Novas funcionalidades são desenvolvidas em repositório privado interno.
+
+## Idioma
+
+- **Documentação**: Português formal e impessoal
+- **Código fonte**: Inglês (nomes de variáveis CSS, classes, funções)
+
+## Arquivo Principal — `src/po-theme-custom.css`
+
+Este arquivo contém TODAS as custom properties do tema (1559+ linhas de CSS). É a única fonte de verdade para a identidade visual TOTVS.
+
+### Sincronização com po-ui/po-style (CRÍTICO)
+
+O arquivo `src/po-theme-custom.css` é um **espelho** do arquivo `src/css/themes/po-theme-default.css` do repositório `po-ui/po-style`. Alterações feitas em um DEVEM ser replicadas no outro. Ignorar esta regra causa divergência visual entre os temas.
+
+## Hierarquia de Tokens CSS
+
+```
+Brand Tokens (--color-brand-01-*)
+  → Action Colors (--color-action-*)
+    → Feedback Colors (--color-feedback-positive-*, --color-feedback-negative-*, ...)
+      → Component Variables (po-button, po-input, po-table, ...)
+```
+
+### Categorias de Tokens
+
+1. **Brand Colors**: `--color-brand-01-lightest` até `--color-brand-01-darkest`
+2. **Action Colors**: `--color-action-default`, `--color-action-hover`, `--color-action-pressed`, `--color-action-disabled`, `--color-action-focus`
+3. **Neutral Colors**: `--color-neutral-light-*`, `--color-neutral-mid-*`, `--color-neutral-dark-*`
+4. **Feedback Colors**: `--color-feedback-positive-*`, `--color-feedback-negative-*`, `--color-feedback-warning-*`, `--color-feedback-info-*`
+5. **Tipografia**: `--font-family-theme`, `--font-family-theme-bold`, `--font-family-theme-extra-light`
+6. **Density**: `--po-density-header-padding`, `--po-density-content-padding`, `--po-density-gap-spacing`
+7. **Categorical**: `--color-01` até `--color-12` (para visualização de dados)
+
+## Regras de Tokens CSS (OBRIGATÓRIO)
+
+### PROIBIDO
+- **Valores hard-coded de cor**: NÃO use `#hex`, `rgb()`, `rgba()`, `hsl()` diretamente. Use SEMPRE variáveis CSS existentes.
+- **Valores hard-coded de espaçamento**: NÃO use `8px`, `16px`, `1rem` diretamente. Use tokens de densidade.
+- **Valores hard-coded de tipografia**: NÃO use `font-family: 'Arial'`, `font-size: 14px`. Use tokens: `var(--font-family-theme)`.
+- **Modificação unilateral**: NÃO modifique `po-theme-custom.css` sem replicar no `po-ui/po-style`.
+- **Novas features**: NÃO publique novas funcionalidades — apenas correções e manutenção.
+
+### OBRIGATÓRIO
+- Todo valor visual DEVE referenciar uma CSS Variable definida no `:root` do tema.
+- Componentes DEVEM cobrir os estados: Enable, Disable, Static, Hover, Focus, Active, Loading.
+- Ao criar novos tokens, siga a nomenclatura: `--{categoria}-{propriedade}-{variante}`.
+
+## Estrutura de Pastas
+
+```
+po-theme-totvs/
+├── .github/
+│   └── workflows/          # CI/CD publishing workflows
+├── src/
+│   ├── assets/fonts/       # Fontes NunitoSans (Regular, Bold, ExtraLight)
+│   ├── index.css           # Entry point CSS (importa po-theme-custom.css)
+│   └── po-theme-custom.css # Definição completa do tema TOTVS
+├── package.json            # Configuração do pacote e scripts de build
+└── README.md               # Documentação de instalação e uso
+```
+
+## Ordem de Carga CSS no angular.json (CRÍTICO)
+
+```json
+"styles": [
+  "node_modules/@totvs/po-theme/css/po-theme-default-variables.min.css",
+  "node_modules/@totvs/po-theme/css/po-theme-default.min.css",
+  "node_modules/@po-ui/style/css/po-theme-core.min.css"
+]
+```
+
+A ordem é OBRIGATÓRIA: **variables → theme → core**. Inverter causa falha na cascata CSS e tokens não serão resolvidos corretamente.
+
+## Comandos de Desenvolvimento
+
+```bash
+# Instalar dependências
+npm install
+
+# Compilar tema (usa @po-ui/theme-cli)
+npm run build
+
+# Criar tarball para teste local
+npm run pack
+
+# Publicar em registry local (localhost:4873)
+npm run publish:local
+```
+
+## Sistema de Fontes
+
+O tema usa a família tipográfica **NunitoSans**:
+- `NunitoSans-Regular.ttf` (400)
+- `NunitoSans-Bold.ttf` (700)
+- `NunitoSans-ExtraLight.ttf` (200)
+
+Declaradas via `@font-face` no `po-theme-custom.css` e referenciadas por:
+- `--font-family-theme`
+- `--font-family-theme-bold`
+- `--font-family-theme-extra-light`
+
+## Integração MCP — Ferramentas de Design
+
+Para conectar agentes de IA às especificações de design do Animalia DS no Figma, configure o MCP do Figma no seu ambiente de desenvolvimento.
+
+**Configuração sugerida para `mcp.json`:**
+```json
+{
+  "mcpServers": {
+    "figma": {
+      "command": "npx",
+      "args": ["-y", "figma-developer-mcp", "--stdio"],
+      "env": {
+        "FIGMA_API_KEY": "<sua-chave-api-figma>"
+      }
+    }
+  }
+}
+```
+
+> **Nota:** A chave da API do Figma deve ser configurada como variável de ambiente, nunca embutida no código.
+
+## Padrões de Commit (Angular conventional commits)
+
+```
+<type>(scope): <descrição curta>
+```
+
+**Types**: `feat`, `fix`, `docs`, `refactor`, `perf`, `test`, `build`  
+**Scope**: Nome do componente **sem** o prefixo `po-` (ex: `feat(button)`, NÃO `feat(po-button)`)
+
+## CI/CD — Canais de Publicação
+
+| Canal | Trigger | npm Tag |
+|-------|---------|---------|
+| Latest | Manual (workflow_dispatch) | `latest` |
+| Next | Manual (workflow_dispatch) | `next` |
+| Beta | Push para branch `beta` | `beta` |
+| Angular 19 LTS | Push para branch `19.x.x` | `v19-lts` |
+| Angular 20 | Push para branch `20.x.x` | `v20-ng` |
+
+## Migração
+
+Para dúvidas sobre migração, abra uma issue neste repositório.

--- a/.github/review.md
+++ b/.github/review.md
@@ -1,0 +1,51 @@
+# Code Review — AI Readiness (po-theme-totvs)
+
+**Data:** 2026-03-25
+**Repositório:** totvs/po-theme-totvs
+**PR:** [#545](https://github.com/totvs/po-theme-totvs/pull/545)
+
+---
+
+## Sumário Executivo
+
+| Critério | Status |
+|----------|--------|
+| Hierarquia de Tokens CSS | Implementado |
+| Proibição de valores hard-coded | Implementado |
+| Sincronização com po-style | Implementado |
+| Ordem de carga CSS | Implementado |
+| Engenharia e Qualidade | Implementado |
+
+## Critérios de Aceite Verificados
+
+### 1. Tokens CSS
+
+- **Hierarquia documentada**: Brand Tokens → Action Colors → Feedback Colors → Component Variables
+- **Categorias de tokens**: Brand, Action, Neutral, Feedback, Typography, Density, Categorical — todas documentadas
+- **Proibição de valores hard-coded**: Explícita — NÃO usar `#hex`, `rgb()`, espaçamentos literais, tipografia literal
+- **Estados obrigatórios**: Enable, Disable, Static, Hover, Focus, Active, Loading
+
+### 2. Sincronização Cross-Repo
+
+- **Espelhamento documentado**: `src/po-theme-custom.css` ↔ `src/css/themes/po-theme-default.css` do `po-ui/po-style`
+- **Regra explícita**: Alterações DEVEM ser sincronizadas entre ambos os repositórios
+- **Proibição de modificação unilateral**: NÃO modificar sem replicar no po-style
+
+### 3. Ordem de Carga CSS
+
+- **Ordem obrigatória documentada**: variables → theme → core
+- **Exemplo de `angular.json`** incluído com os três arquivos na ordem correta
+
+### 4. Engenharia e Qualidade
+
+- **Conventional Commits**: Padrão `<type>(scope): <descrição curta>` documentado
+- **CI/CD**: Canais de publicação documentados (latest, next, beta, v19-lts, v20-ng)
+- **Aviso de descontinuação**: Explícito — suporte até v23.x.x
+
+## Arquivos de AI Readiness
+
+| Arquivo | Propósito |
+|---------|-----------|
+| `AGENTS.md` | Ponto de entrada com visão geral, tokens e regras |
+| `.github/instructions/agents-instructions.md` | Instruções completas de desenvolvimento |
+| `mcp.json` | Configuração de MCP servers (Figma) |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,77 @@
+# AGENTS.md — PO Theme TOTVS
+
+> **ATENÇÃO**: Este repositório está em processo de descontinuação.
+> Suporte até v23.x.x. Após essa versão, o pacote deixará de ser mantido.
+> Novas funcionalidades são desenvolvidas em repositório privado interno.
+
+## Instruções Detalhadas
+
+Consulte o arquivo principal de instruções:
+- **[.github/instructions/agents-instructions.md](.github/instructions/agents-instructions.md)** — Instruções completas para desenvolvimento
+
+## Visão Geral
+
+Tema padrão da TOTVS para aplicações PO UI. Pacote: `@totvs/po-theme`.
+Estende o `@po-ui/style` com branding TOTVS (cores, tipografia, espaçamentos).
+
+## Arquivo Principal
+
+`src/po-theme-custom.css` — Contém TODAS as custom properties do tema (1559+ linhas).
+Este arquivo é um **espelho** de `src/css/themes/po-theme-default.css` do repositório `po-ui/po-style`.
+Alterações DEVEM ser sincronizadas entre ambos os repositórios.
+
+## Hierarquia de Tokens CSS
+
+```
+Brand Tokens (--color-brand-01-*)
+  → Action Colors (--color-action-*)
+    → Component Variables (po-button, po-input, ...)
+```
+
+### PROIBIDO
+- **NÃO** adicione valores hard-coded (hex, rgb). Use SEMPRE variáveis CSS existentes.
+- **NÃO** modifique `po-theme-custom.css` sem replicar a alteração no `po-ui/po-style`.
+- **NÃO** publique novas features — apenas correções e manutenção.
+
+## Estrutura
+
+```
+src/
+├── assets/
+│   └── fonts/              # Fontes NunitoSans (Regular, Bold, ExtraLight)
+├── index.css               # Entry point CSS (importa po-theme-custom.css)
+└── po-theme-custom.css     # Definição completa do tema TOTVS
+```
+
+## Ordem de Carga CSS no angular.json (CRÍTICO)
+
+```json
+"styles": [
+  "node_modules/@totvs/po-theme/css/po-theme-default-variables.min.css",
+  "node_modules/@totvs/po-theme/css/po-theme-default.min.css",
+  "node_modules/@po-ui/style/css/po-theme-core.min.css"
+]
+```
+
+A ordem é OBRIGATÓRIA: variables → theme → core. Inverter causa falha na cascata CSS.
+
+## Comandos Essenciais
+
+```bash
+npm install                    # Instalar dependências
+npm run build                  # Compilar tema (usa @po-ui/theme-cli)
+npm run pack                   # Criar tarball
+npm run publish:local          # Publicar em localhost:4873
+```
+
+## Padrões de Commit (Angular conventional commits)
+
+```
+<type>(scope): <descrição curta>
+```
+
+**Types**: `feat`, `fix`, `docs`, `refactor`, `perf`, `test`, `build`
+
+## Migração
+
+Para dúvidas sobre migração, abra uma issue neste repositório.

--- a/mcp.json
+++ b/mcp.json
@@ -1,0 +1,11 @@
+{
+  "mcpServers": {
+    "figma": {
+      "command": "npx",
+      "args": ["-y", "figma-developer-mcp", "--stdio"],
+      "env": {
+        "FIGMA_API_KEY": "${FIGMA_API_KEY}"
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Adiciona documentação estruturada para preparar o repositório `po-theme-totvs` para trabalho com agentes de IA. Nenhuma alteração de código funcional — apenas arquivos de documentação markdown e configuração JSON.

**Arquivos adicionados:**
- **`AGENTS.md`** — Ponto de entrada para agentes de IA com hierarquia de tokens CSS, regras proibitivas (hard-coded values), sincronização obrigatória com `po-ui/po-style`, ordem crítica de carga CSS e comandos essenciais
- **`.github/instructions/agents-instructions.md`** — Instruções completas cobrindo: categorias de tokens (Brand, Action, Neutral, Feedback, Typography, Density, Categorical), regras PROIBIDO/OBRIGATÓRIO, sincronização cross-repo, sistema de fontes NunitoSans, integração MCP (Figma), canais de CI/CD e padrões de commit
- **`.github/review.md`** — Documentação de code-review com critérios de aceite verificados e sumário executivo
- **`mcp.json`** — Configuração do servidor MCP Figma para integração com ferramentas de design

**Destaques da documentação:**
- Estados de componente padronizados: Enable, Disable, Static, Hover, Focus, Active, Loading
- Regra de scope de commit com tom imperativo: `feat(button)`, NÃO `feat(po-button)` — alinhado com padrão dos repositórios po-angular e po-style
- Proibição explícita de valores hard-coded (hex, rgb, espaçamentos literais, tipografia literal)

### Updates since last revision
- Removida configuração do `context7` do `mcp.json` e das referências em `agents-instructions.md` e `review.md` — agora apenas o servidor MCP Figma é configurado

## Review & Testing Checklist for Human

- [ ] **Sincronização cross-repo**: Verificar se a regra de espelhamento (`po-theme-custom.css` ↔ `po-theme-default.css` do `po-ui/po-style`) está alinhada com o workflow real do time — instrução mais crítica do PR; se incorreta, causa divergência entre temas
- [ ] **Nomes de tokens**: Confirmar que os nomes de categorias listados em `agents-instructions.md` (ex: `--color-brand-01-lightest`, `--color-action-default`, `--po-density-header-padding`) existem de fato no `src/po-theme-custom.css`
- [ ] **`mcp.json`**: Confirmar que a sintaxe `${FIGMA_API_KEY}` é interpolada corretamente como variável de ambiente pelas ferramentas que o consomem (e não como string literal)
- [ ] **Aviso de descontinuação**: Verificar se "Suporte até v23.x.x" está alinhado com a estratégia atual do repositório

### Notes
- Alteração puramente documental — sem impacto em código, build ou CI.
- Este PR é parte de um conjunto de 3 PRs (po-angular, po-style, po-theme-totvs) para AI-readiness.
- Todos os arquivos de instruções ficam em `.github/` (agnóstico de ferramenta de IA, sem vínculo com Copilot, Cursor, etc.)
- Documentação em português formal e impessoal; nomes de arquivos e código em inglês, conforme convenção do projeto.

Link to Devin session: https://totvs.devinenterprise.com/sessions/be9c05d3c0ae4f37bf479d7df4bb7ae6
Requested by: @brunopbrito-totvs
<!-- devin-review-badge-begin -->

---

<a href="https://totvs.devinenterprise.com/review/totvs/po-theme-totvs/pull/545" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
